### PR TITLE
feat: Add attachment download functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,26 @@ Retrieves a list of cards contained in the specified list ID.
 ```
 
 ### `trello_get_lists`
-Retrieves all lists in the board.
+Retrieves all lists in the specified board.
 
 ```typescript
 {
   name: "trello_get_lists",
-  arguments: {}
+  arguments: {
+    boardId: string; // The ID of the Trello board to get lists from
+  }
 }
 ```
 
 ### `trello_get_recent_activity`
-Retrieves the most recent board activity. The `limit` argument can specify how many to retrieve (default: 10).
+Retrieves the most recent activity for a specified board. The `limit` argument can specify how many to retrieve (default: 10).
 
 ```typescript
 {
   name: "trello_get_recent_activity",
   arguments: {
-    limit?: number; // Optional: number of activities to retrieve
+    boardId: string; // The ID of the Trello board to get activity from
+    limit?: number;  // Optional: number of activities to retrieve
   }
 }
 ```
@@ -95,13 +98,14 @@ Archives (closes) the specified card.
 ```
 
 ### `trello_add_list`
-Adds a new list to the board.
+Adds a new list to the specified board.
 
 ```typescript
 {
   name: "trello_add_list",
   arguments: {
-    name: string; // Name of the new list
+    boardId: string; // The ID of the Trello board to add the list to
+    name: string;    // Name of the new list
   }
 }
 ```
@@ -140,6 +144,48 @@ Performs a cross-board search across all boards in the workspace (organization),
   }
 }
 ```
+
+### `trello_get_card_attachments`
+Retrieves all attachments from a specified card. Returns attachment metadata including name, file size, MIME type, and URL. Use this to discover what attachments exist on a card before downloading.
+
+```typescript
+{
+  name: "trello_get_card_attachments",
+  arguments: {
+    cardId: string;  // The ID of the Trello card to get attachments from
+  }
+}
+```
+
+Returns an array of attachment objects with the following properties:
+- `id`: Unique identifier for the attachment
+- `name`: Display name of the attachment
+- `url`: URL to access/download the attachment
+- `bytes`: Size of the attachment in bytes (0 for external links)
+- `mimeType`: MIME type (e.g., "image/png", "application/pdf")
+- `date`: ISO 8601 date string when the attachment was added
+- `isUpload`: Whether this is a Trello upload (true) or external link (false)
+- `fileName`: Filename of the attachment
+
+### `trello_download_attachment`
+Downloads a specific attachment from a Trello card. For files uploaded directly to Trello, returns the content as base64-encoded data. For external links, returns the URL.
+
+```typescript
+{
+  name: "trello_download_attachment",
+  arguments: {
+    cardId: string;       // The ID of the Trello card containing the attachment
+    attachmentId: string; // The ID of the attachment to download
+  }
+}
+```
+
+Returns an object with:
+- `attachment`: The full attachment metadata
+- `content`: Base64-encoded file content (for Trello uploads) or `null` (for external links)
+- `url`: Direct URL to the attachment
+
+**Usage tip**: First use `trello_get_card_attachments` to list all attachments and get their IDs, then use `trello_download_attachment` to download specific files.
 
 ## Rate Limiting
 
@@ -201,15 +247,16 @@ To integrate this MCP server with Claude Desktop, add the following configuratio
         ],
         "env": {
           "TRELLO_API_KEY": "{YOUR_KEY}",
-          "TRELLO_TOKEN": "{YOUR_TOKEN}",
-          "TRELLO_BOARD_ID": "{YOUR_BOARD_ID}"
+          "TRELLO_TOKEN": "{YOUR_TOKEN}"
         }
       }
     }
   }
   ```
 
-Make sure to replace {YOUR_NODE_PATH}, {YOUR_PATH}, {YOUR_KEY}, {YOUR_TOKEN}, and {YOUR_BOARD_ID} with the appropriate values for your environment.
+Make sure to replace {YOUR_NODE_PATH}, {YOUR_PATH}, {YOUR_KEY}, and {YOUR_TOKEN} with the appropriate values for your environment.
+
+**Note:** Board IDs are passed as parameters to individual tools rather than configured globally, allowing you to work with multiple boards.
 
 ## Contributing
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { TrelloConfig, TrelloCard, TrelloList, TrelloAction, TrelloMember } from './types.js';
+import { TrelloConfig, TrelloCard, TrelloList, TrelloAction, TrelloMember, TrelloAttachment } from './types.js';
 import { createTrelloRateLimiters } from './rate-limiter.js';
 
 export class TrelloClient {
@@ -47,16 +47,29 @@ export class TrelloClient {
     });
   }
 
-  async getLists(): Promise<TrelloList[]> {
+  /**
+   * Retrieves all lists for a specific board.
+   *
+   * @param boardId - The ID of the board to get lists from
+   * @returns Promise resolving to an array of TrelloList objects
+   */
+  async getLists(boardId: string): Promise<TrelloList[]> {
     return this.handleRequest(async () => {
-      const response = await this.axiosInstance.get(`/boards/${this.config.boardId}/lists`);
+      const response = await this.axiosInstance.get(`/boards/${boardId}/lists`);
       return response.data;
     });
   }
 
-  async getRecentActivity(limit: number = 10): Promise<TrelloAction[]> {
+  /**
+   * Retrieves recent activity for a specific board.
+   *
+   * @param boardId - The ID of the board to get activity from
+   * @param limit - Maximum number of activities to retrieve (default: 10)
+   * @returns Promise resolving to an array of TrelloAction objects
+   */
+  async getRecentActivity(boardId: string, limit: number = 10): Promise<TrelloAction[]> {
     return this.handleRequest(async () => {
-      const response = await this.axiosInstance.get(`/boards/${this.config.boardId}/actions`, {
+      const response = await this.axiosInstance.get(`/boards/${boardId}/actions`, {
         params: { limit },
       });
       return response.data;
@@ -109,11 +122,18 @@ export class TrelloClient {
     });
   }
 
-  async addList(name: string): Promise<TrelloList> {
+  /**
+   * Adds a new list to a specific board.
+   *
+   * @param boardId - The ID of the board to add the list to
+   * @param name - The name of the new list
+   * @returns Promise resolving to the created TrelloList object
+   */
+  async addList(boardId: string, name: string): Promise<TrelloList> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.post('/lists', {
         name,
-        idBoard: this.config.boardId,
+        idBoard: boardId,
       });
       return response.data;
     });
@@ -147,6 +167,115 @@ export class TrelloClient {
         },
       });
       return response.data;
+    });
+  }
+
+  /**
+   * Retrieves all attachments for a specific card.
+   *
+   * @param cardId - The ID of the card to get attachments from
+   * @returns Promise resolving to an array of TrelloAttachment objects
+   *
+   * @example
+   * const attachments = await client.getCardAttachments('abc123');
+   * console.log(attachments.map(a => a.name));
+   */
+  async getCardAttachments(cardId: string): Promise<TrelloAttachment[]> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.get(`/cards/${cardId}/attachments`);
+      return response.data;
+    });
+  }
+
+  /**
+   * Downloads an attachment from a Trello card and returns its content as base64.
+   *
+   * Note: This method is suitable for small to medium-sized files. For very large files,
+   * consider using the attachment URL directly with appropriate streaming.
+   *
+   * @param cardId - The ID of the card containing the attachment
+   * @param attachmentId - The ID of the attachment to download
+   * @returns Promise resolving to an object containing:
+   *   - attachment: The attachment metadata
+   *   - content: Base64-encoded file content (for Trello uploads)
+   *   - url: Direct URL to the attachment (for external links or as fallback)
+   *
+   * @example
+   * const result = await client.downloadAttachment('cardId', 'attachmentId');
+   * if (result.content) {
+   *   // Decode base64 content
+   *   const buffer = Buffer.from(result.content, 'base64');
+   * }
+   */
+  async downloadAttachment(cardId: string, attachmentId: string): Promise<{
+    attachment: TrelloAttachment;
+    content: string | null;
+    url: string;
+    error?: string;
+  }> {
+    return this.handleRequest(async () => {
+      // First, get the attachment metadata
+      const metadataResponse = await this.axiosInstance.get(
+        `/cards/${cardId}/attachments/${attachmentId}`
+      );
+      const attachment: TrelloAttachment = metadataResponse.data;
+
+      // If it's not a Trello upload (external link), just return the URL
+      if (!attachment.isUpload) {
+        return {
+          attachment,
+          content: null,
+          url: attachment.url,
+        };
+      }
+
+      // For Trello uploads, download the actual content
+      // The download endpoint requires OAuth header authentication (not query params)
+      try {
+        const contentResponse = await axios.get(attachment.url, {
+          responseType: 'arraybuffer',
+          // Follow redirects (Trello often redirects to S3 signed URLs)
+          maxRedirects: 5,
+          // Increase timeout for larger files
+          timeout: 60000,
+          headers: {
+            'Accept': '*/*',
+            'Authorization': `OAuth oauth_consumer_key="${this.config.apiKey}", oauth_token="${this.config.token}"`,
+          },
+        });
+
+        // Convert to base64 for safe transmission
+        const base64Content = Buffer.from(contentResponse.data).toString('base64');
+
+        return {
+          attachment,
+          content: base64Content,
+          url: attachment.url,
+        };
+      } catch (error) {
+        // Extract meaningful error message
+        let errorMessage = 'Unknown error';
+        if (axios.isAxiosError(error)) {
+          if (error.response) {
+            errorMessage = `HTTP ${error.response.status}: ${error.response.statusText}`;
+          } else if (error.code) {
+            errorMessage = `Network error: ${error.code} - ${error.message}`;
+          } else {
+            errorMessage = error.message;
+          }
+        } else if (error instanceof Error) {
+          errorMessage = error.message;
+        }
+
+        console.error('Failed to download attachment content:', errorMessage);
+
+        return {
+          attachment,
+          content: null,
+          url: attachment.url,
+          error: `Download failed: ${errorMessage}`,
+        };
+      }
     });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 export interface TrelloConfig {
   apiKey: string;
   token: string;
-  boardId: string;
 }
 
 export interface TrelloCard {
@@ -62,6 +61,31 @@ export interface TrelloMember {
   fullName: string;
   username: string;
   avatarUrl: string | null;
+}
+
+/**
+ * Represents an attachment on a Trello card.
+ * Attachments can be files uploaded directly to Trello or links to external resources.
+ */
+export interface TrelloAttachment {
+  /** Unique identifier for the attachment */
+  id: string;
+  /** Display name of the attachment */
+  name: string;
+  /** URL to access/download the attachment */
+  url: string;
+  /** Size of the attachment in bytes (0 for external links) */
+  bytes: number;
+  /** MIME type of the attachment (e.g., "image/png", "application/pdf") */
+  mimeType: string;
+  /** ISO 8601 date string when the attachment was added */
+  date: string;
+  /** ID of the member who added the attachment */
+  idMember: string;
+  /** Whether this is an upload to Trello (true) or an external link (false) */
+  isUpload: boolean;
+  /** Filename of the attachment */
+  fileName: string;
 }
 
 export interface RateLimiter {


### PR DESCRIPTION
## Summary

This PR adds two new tools for working with Trello card attachments:

- **`trello_get_card_attachments`**: Lists all attachments on a card with metadata (name, size, MIME type, URL)
- **`trello_download_attachment`**: Downloads attachment content as base64 for Trello uploads, or returns URL for external links

Additionally, this PR makes `boardId` a required parameter on relevant tools (`trello_get_lists`, `trello_get_recent_activity`, `trello_add_list`) instead of a global environment variable, allowing users to work with multiple boards.

## Changes

### New Features
- Added `TrelloAttachment` type with full JSDoc documentation
- Implemented `getCardAttachments()` method in TrelloClient
- Implemented `downloadAttachment()` method with:
  - OAuth header authentication (required by Trello's download endpoint)
  - Proper redirect handling for S3 signed URLs
  - Base64 encoding for binary file transmission
  - Detailed error messages for troubleshooting

### Refactoring
- Removed `TRELLO_BOARD_ID` from required environment variables
- Made `boardId` a mandatory parameter on board-specific tools
- Updated tool definitions and handlers accordingly

### Documentation
- Added documentation for new attachment tools in README
- Updated existing tool documentation to reflect `boardId` parameter changes
- Updated configuration example

## Test plan

- [x] Tested `trello_get_card_attachments` - returns correct attachment metadata
- [x] Tested `trello_download_attachment` with PDF upload - returns valid base64 content
- [x] Tested `trello_download_attachment` with external link - returns URL only
- [x] Verified OAuth header authentication works (query params return 401)
- [x] Verified base64 decodes to valid file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)