### PR TITLE
Add new MCP tools: move card, comments, and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,55 @@ Performs a cross-board search across all boards in the workspace (organization),
 }
 ```
 
+### `trello_move_card`
+Moves a card to a different list.
+
+```typescript
+{
+  name: "trello_move_card",
+  arguments: {
+    cardId: string;  // The ID of the card to move
+    listId: string;  // The ID of the destination list
+  }
+}
+```
+
+### `trello_add_comment`
+Adds a comment to a card.
+
+```typescript
+{
+  name: "trello_add_comment",
+  arguments: {
+    cardId: string;  // The ID of the card to comment on
+    text: string;    // The comment text
+  }
+}
+```
+
+### `trello_get_labels`
+Retrieves all labels on the board.
+
+```typescript
+{
+  name: "trello_get_labels",
+  arguments: {}
+}
+```
+
+### `trello_add_label`
+Creates a new label on the board.
+
+```typescript
+{
+  name: "trello_add_label",
+  arguments: {
+    name: string;   // The name of the label
+    color: string;  // The color (green, yellow, orange, red, purple, blue, sky, lime, pink, black)
+  }
+}
+```
+
 ## Rate Limiting
 
 The server implements a token bucket algorithm for rate limiting to comply with Trello's API limits:

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,89 @@ const trelloSearchAllBoardsTool: Tool = {
   },
 };
 
+interface MoveCardArgs {
+  cardId: string;
+  listId: string;
+}
+
+const trelloMoveCardTool: Tool = {
+  name: "trello_move_card",
+  description: "Moves a card to a different list.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      cardId: {
+        type: "string",
+        description: "The ID of the card to move",
+      },
+      listId: {
+        type: "string",
+        description: "The ID of the destination list",
+      },
+    },
+    required: ["cardId", "listId"],
+  },
+};
+
+interface AddCommentArgs {
+  cardId: string;
+  text: string;
+}
+
+const trelloAddCommentTool: Tool = {
+  name: "trello_add_comment",
+  description: "Adds a comment to a card.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      cardId: {
+        type: "string",
+        description: "The ID of the card to comment on",
+      },
+      text: {
+        type: "string",
+        description: "The comment text",
+      },
+    },
+    required: ["cardId", "text"],
+  },
+};
+
+interface GetLabelsArgs {}
+
+const trelloGetLabelsTool: Tool = {
+  name: "trello_get_labels",
+  description: "Retrieves all labels in the board.",
+  inputSchema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+interface AddLabelArgs {
+  name: string;
+  color: string;
+}
+
+const trelloAddLabelTool: Tool = {
+  name: "trello_add_label",
+  description: "Creates a new label on the board.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "The name of the label",
+      },
+      color: {
+        type: "string",
+        description: "The color of the label (green, yellow, orange, red, purple, blue, sky, lime, pink, black)",
+      },
+    },
+    required: ["name", "color"],
+  },
+};
+
 // --------------------------------------------------
 // Main server implementation
 // --------------------------------------------------
@@ -421,6 +504,58 @@ async function main() {
           };
         }
 
+        // --------------------------------------------------
+        // Move card to another list
+        // --------------------------------------------------
+        case "trello_move_card": {
+          const args = request.params.arguments as unknown as MoveCardArgs;
+          if (!args.cardId || !args.listId) {
+            throw new Error("Missing required arguments: cardId, listId");
+          }
+          const response = await trelloClient.moveCard(args.cardId, args.listId);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        // --------------------------------------------------
+        // Add comment to card
+        // --------------------------------------------------
+        case "trello_add_comment": {
+          const args = request.params.arguments as unknown as AddCommentArgs;
+          if (!args.cardId || !args.text) {
+            throw new Error("Missing required arguments: cardId, text");
+          }
+          const response = await trelloClient.addComment(args.cardId, args.text);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        // --------------------------------------------------
+        // Get all labels in the board
+        // --------------------------------------------------
+        case "trello_get_labels": {
+          const response = await trelloClient.getLabels();
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
+        // --------------------------------------------------
+        // Create a new label on the board
+        // --------------------------------------------------
+        case "trello_add_label": {
+          const args = request.params.arguments as unknown as AddLabelArgs;
+          if (!args.name || !args.color) {
+            throw new Error("Missing required arguments: name, color");
+          }
+          const response = await trelloClient.addLabel(args.name, args.color);
+          return {
+            content: [{ type: "text", text: JSON.stringify(response) }],
+          };
+        }
+
         default:
           throw new Error(`Unknown tool: ${request.params.name}`);
       }
@@ -456,6 +591,10 @@ async function main() {
         trelloArchiveListTool,
         trelloGetMyCardsTool,
         trelloSearchAllBoardsTool,
+        trelloMoveCardTool,
+        trelloAddCommentTool,
+        trelloGetLabelsTool,
+        trelloAddLabelTool,
       ],
     };
   });

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { TrelloConfig, TrelloCard, TrelloList, TrelloAction, TrelloMember } from './types.js';
+import { TrelloConfig, TrelloCard, TrelloList, TrelloAction, TrelloMember, TrelloLabel } from './types.js';
 import { createTrelloRateLimiters } from './rate-limiter.js';
 
 export class TrelloClient {
@@ -145,6 +145,59 @@ export class TrelloClient {
           cards_limit: limit,
           organization: true,
         },
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * カードを別のリストに移動する
+   * @param cardId 移動するカードのID
+   * @param listId 移動先のリストID
+   */
+  async moveCard(cardId: string, listId: string): Promise<TrelloCard> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.put(`/cards/${cardId}`, {
+        idList: listId,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * カードにコメントを追加する
+   * @param cardId コメントを追加するカードのID
+   * @param text コメント本文
+   */
+  async addComment(cardId: string, text: string): Promise<TrelloAction> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post(`/cards/${cardId}/actions/comments`, {
+        text,
+      });
+      return response.data;
+    });
+  }
+
+  /**
+   * ボードのラベル一覧を取得する
+   */
+  async getLabels(): Promise<TrelloLabel[]> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.get(`/boards/${this.config.boardId}/labels`);
+      return response.data;
+    });
+  }
+
+  /**
+   * ボードにラベルを作成する
+   * @param name ラベル名
+   * @param color ラベルの色 (green, yellow, orange, red, purple, blue, sky, lime, pink, black, null)
+   */
+  async addLabel(name: string, color: string): Promise<TrelloLabel> {
+    return this.handleRequest(async () => {
+      const response = await this.axiosInstance.post(`/boards/${this.config.boardId}/labels`, {
+        name,
+        color,
       });
       return response.data;
     });

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -151,9 +151,9 @@ export class TrelloClient {
   }
 
   /**
-   * カードを別のリストに移動する
-   * @param cardId 移動するカードのID
-   * @param listId 移動先のリストID
+   * Moves a card to a different list
+   * @param cardId The ID of the card to move
+   * @param listId The ID of the destination list
    */
   async moveCard(cardId: string, listId: string): Promise<TrelloCard> {
     return this.handleRequest(async () => {
@@ -165,9 +165,9 @@ export class TrelloClient {
   }
 
   /**
-   * カードにコメントを追加する
-   * @param cardId コメントを追加するカードのID
-   * @param text コメント本文
+   * Adds a comment to a card
+   * @param cardId The ID of the card to comment on
+   * @param text The comment text
    */
   async addComment(cardId: string, text: string): Promise<TrelloAction> {
     return this.handleRequest(async () => {
@@ -179,7 +179,7 @@ export class TrelloClient {
   }
 
   /**
-   * ボードのラベル一覧を取得する
+   * Retrieves all labels on the board
    */
   async getLabels(): Promise<TrelloLabel[]> {
     return this.handleRequest(async () => {
@@ -189,9 +189,9 @@ export class TrelloClient {
   }
 
   /**
-   * ボードにラベルを作成する
-   * @param name ラベル名
-   * @param color ラベルの色 (green, yellow, orange, red, purple, blue, sky, lime, pink, black, null)
+   * Creates a new label on the board
+   * @param name The name of the label
+   * @param color The color of the label (green, yellow, orange, red, purple, blue, sky, lime, pink, black, null)
    */
   async addLabel(name: string, color: string): Promise<TrelloLabel> {
     return this.handleRequest(async () => {


### PR DESCRIPTION
## Summary
  This PR adds four new Trello MCP tools to extend the functionality:

  - **trello_move_card** - Move a card to a different list
  - **trello_add_comment** - Add a comment to a card
  - **trello_get_labels** - Retrieve all labels on the board
  - **trello_add_label** - Create a new label on the board

  ## Changes
  - `src/index.ts`: Added tool definitions and request handlers for the four new tools
  - `src/trello-client.ts`: Implemented API methods (`moveCard`, `addComment`, `getLabels`, `addLabel`)
  - `README.md`: Added documentation for the new tools