### PR TITLE
Security hardening: board scoping, bounded retries, safe logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,23 +8,21 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 
-// --------------------------------------------------
-// Imports related to TrelloClient (provided classes and types)
-// --------------------------------------------------
-import { TrelloClient } from "./trello-client.js";  // ←Change the path according to your own configuration
+import { TrelloClient } from "./trello-client.js";
 import {
-  TrelloConfig,
-  TrelloCard,
-  TrelloList,
-  TrelloAction,
-} from "./types.js"; // ←Change the path according to your own configuration
+  validateGetCardsListRequest,
+  validateGetRecentActivityRequest,
+  validateAddCardRequest,
+  validateUpdateCardRequest,
+  validateArchiveCardRequest,
+  validateAddListRequest,
+  validateArchiveListRequest,
+  validateSearchRequest,
+} from "./validators.js";
 
 // --------------------------------------------------
 // Define tools for Trello (Tool)
 // --------------------------------------------------
-interface GetCardsByListArgs {
-  listId: string;
-}
 
 const trelloGetCardsByListTool: Tool = {
   name: "trello_get_cards_by_list",
@@ -41,8 +39,6 @@ const trelloGetCardsByListTool: Tool = {
   },
 };
 
-interface GetListsArgs {}
-
 const trelloGetListsTool: Tool = {
   name: "trello_get_lists",
   description: "Retrieves all lists in the board.",
@@ -51,10 +47,6 @@ const trelloGetListsTool: Tool = {
     properties: {},
   },
 };
-
-interface GetRecentActivityArgs {
-  limit?: number;
-}
 
 const trelloGetRecentActivityTool: Tool = {
   name: "trello_get_recent_activity",
@@ -70,14 +62,6 @@ const trelloGetRecentActivityTool: Tool = {
     },
   },
 };
-
-interface AddCardArgs {
-  listId: string;
-  name: string;
-  description?: string;
-  dueDate?: string;
-  labels?: string[];
-}
 
 const trelloAddCardTool: Tool = {
   name: "trello_add_card",
@@ -105,14 +89,6 @@ const trelloAddCardTool: Tool = {
     required: ["listId", "name"],
   },
 };
-
-interface UpdateCardArgs {
-  cardId: string;
-  name?: string;
-  description?: string;
-  dueDate?: string;
-  labels?: string[];
-}
 
 const trelloUpdateCardTool: Tool = {
   name: "trello_update_card",
@@ -147,10 +123,6 @@ const trelloUpdateCardTool: Tool = {
   },
 };
 
-interface ArchiveCardArgs {
-  cardId: string;
-}
-
 const trelloArchiveCardTool: Tool = {
   name: "trello_archive_card",
   description: "Archives (closes) the specified card.",
@@ -165,10 +137,6 @@ const trelloArchiveCardTool: Tool = {
     required: ["cardId"],
   },
 };
-
-interface AddListArgs {
-  name: string;
-}
 
 const trelloAddListTool: Tool = {
   name: "trello_add_list",
@@ -185,10 +153,6 @@ const trelloAddListTool: Tool = {
   },
 };
 
-interface ArchiveListArgs {
-  listId: string;
-}
-
 const trelloArchiveListTool: Tool = {
   name: "trello_archive_list",
   description: "Archives (closes) the specified list.",
@@ -204,26 +168,19 @@ const trelloArchiveListTool: Tool = {
   },
 };
 
-interface GetMyCardsArgs {}
-
 const trelloGetMyCardsTool: Tool = {
   name: "trello_get_my_cards",
-  description: "Retrieves all cards related to your account.",
+  description: "Retrieves cards assigned to you on the configured board.",
   inputSchema: {
     type: "object",
     properties: {},
   },
 };
 
-interface TrelloSearchAllBoardsArgs {
-  query: string;
-  limit?: number;
-}
-
-const trelloSearchAllBoardsTool: Tool = {
-  name: "trello_search_all_boards",
+const trelloSearchBoardTool: Tool = {
+  name: "trello_search_board",
   description:
-    "Performs a cross-board search across all boards in the workspace (organization) (depending on plan/permissions).",
+    "Searches for cards and other items within the configured board.",
   inputSchema: {
     type: "object",
     properties: {
@@ -276,135 +233,86 @@ async function main() {
   // Handle CallToolRequest
   // --------------------------------------------------
   server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
-    console.error("Received CallToolRequest:", request);
+    console.error("Received CallToolRequest:", request.params.name);
     try {
-      if (!request.params.arguments) {
-        throw new Error("No arguments provided");
-      }
+      const args = (request.params.arguments ?? {}) as Record<string, unknown>;
 
       switch (request.params.name) {
-        // --------------------------------------------------
-        // Retrieve the list of cards by specifying the listId
-        // --------------------------------------------------
         case "trello_get_cards_by_list": {
-          const args = request.params.arguments as unknown as GetCardsByListArgs;
-          if (!args.listId) {
-            throw new Error("Missing required argument: listId");
-          }
-          const response = await trelloClient.getCardsByList(args.listId);
+          const validated = validateGetCardsListRequest(args);
+          const response = await trelloClient.getCardsByList(validated.listId);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Retrieve all lists in the board
-        // --------------------------------------------------
         case "trello_get_lists": {
-          // No arguments
           const response = await trelloClient.getLists();
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Recent activity on the board
-        // --------------------------------------------------
         case "trello_get_recent_activity": {
-          const args = request.params.arguments as unknown as GetRecentActivityArgs;
-          const limit = args.limit ?? 10; // Default 10
-          const response = await trelloClient.getRecentActivity(limit);
+          const validated = validateGetRecentActivityRequest(args);
+          const response = await trelloClient.getRecentActivity(validated.limit);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Create a new card
-        // --------------------------------------------------
         case "trello_add_card": {
-          const args = request.params.arguments as unknown as AddCardArgs;
-          if (!args.listId || !args.name) {
-            throw new Error("Missing required arguments: listId, name");
-          }
+          const validated = validateAddCardRequest(args);
           const response = await trelloClient.addCard({
-            listId: args.listId,
-            name: args.name,
-            description: args.description,
-            dueDate: args.dueDate,
-            labels: args.labels,
+            listId: validated.listId,
+            name: validated.name,
+            description: validated.description,
+            dueDate: validated.dueDate,
+            labels: validated.labels,
           });
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Update card
-        // --------------------------------------------------
         case "trello_update_card": {
-          const args = request.params.arguments as unknown as UpdateCardArgs;
-          if (!args.cardId) {
-            throw new Error("Missing required argument: cardId");
-          }
+          const validated = validateUpdateCardRequest(args);
           const response = await trelloClient.updateCard({
-            cardId: args.cardId,
-            name: args.name,
-            description: args.description,
-            dueDate: args.dueDate,
-            labels: args.labels,
+            cardId: validated.cardId,
+            name: validated.name,
+            description: validated.description,
+            dueDate: validated.dueDate,
+            labels: validated.labels,
           });
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Archive card
-        // --------------------------------------------------
         case "trello_archive_card": {
-          const args = request.params.arguments as unknown as ArchiveCardArgs;
-          if (!args.cardId) {
-            throw new Error("Missing required argument: cardId");
-          }
-          const response = await trelloClient.archiveCard(args.cardId);
+          const validated = validateArchiveCardRequest(args);
+          const response = await trelloClient.archiveCard(validated.cardId);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Create a new list
-        // --------------------------------------------------
         case "trello_add_list": {
-          const args = request.params.arguments as unknown as AddListArgs;
-          if (!args.name) {
-            throw new Error("Missing required argument: name");
-          }
-          const response = await trelloClient.addList(args.name);
+          const validated = validateAddListRequest(args);
+          const response = await trelloClient.addList(validated.name);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Archive list
-        // --------------------------------------------------
         case "trello_archive_list": {
-          const args = request.params.arguments as unknown as ArchiveListArgs;
-          if (!args.listId) {
-            throw new Error("Missing required argument: listId");
-          }
-          const response = await trelloClient.archiveList(args.listId);
+          const validated = validateArchiveListRequest(args);
+          const response = await trelloClient.archiveList(validated.listId);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
         }
 
-        // --------------------------------------------------
-        // Retrieve all cards related to yourself
-        // --------------------------------------------------
         case "trello_get_my_cards": {
           const response = await trelloClient.getMyCards();
           return {
@@ -412,10 +320,9 @@ async function main() {
           };
         }
 
-        case "trello_search_all_boards": {
-          const args = request.params.arguments as unknown as TrelloSearchAllBoardsArgs;
-          const limit = args.limit ?? 10;
-          const response = await trelloClient.searchAllBoards(args.query, limit);
+        case "trello_search_board": {
+          const validated = validateSearchRequest(args);
+          const response = await trelloClient.searchBoard(validated.query, validated.limit);
           return {
             content: [{ type: "text", text: JSON.stringify(response) }],
           };
@@ -425,7 +332,7 @@ async function main() {
           throw new Error(`Unknown tool: ${request.params.name}`);
       }
     } catch (error) {
-      console.error("Error executing tool:", error);
+      console.error("Error executing tool:", error instanceof Error ? error.message : String(error));
       return {
         content: [
           {
@@ -455,7 +362,7 @@ async function main() {
         trelloAddListTool,
         trelloArchiveListTool,
         trelloGetMyCardsTool,
-        trelloSearchAllBoardsTool,
+        trelloSearchBoardTool,
       ],
     };
   });
@@ -471,6 +378,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error("Fatal error in main():", error);
+  console.error("Fatal error in main():", error instanceof Error ? error.message : String(error));
   process.exit(1);
 });

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -40,7 +40,7 @@ export class TokenBucketRateLimiter implements RateLimiter {
         } else {
           // Calculate time until next token is available
           const tokensNeeded = 1 - this.tokens;
-          const msToWait = (tokensNeeded / this.refillRate) * 1000;
+          const msToWait = tokensNeeded / this.refillRate;
           setTimeout(check, Math.min(msToWait, 100)); // Check at most every 100ms
         }
       };

--- a/src/trello-client.ts
+++ b/src/trello-client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { TrelloConfig, TrelloCard, TrelloList, TrelloAction, TrelloMember } from './types.js';
+import { TrelloConfig, TrelloCard, TrelloList, TrelloAction } from './types.js';
 import { createTrelloRateLimiters } from './rate-limiter.js';
 
 export class TrelloClient {
@@ -24,15 +24,21 @@ export class TrelloClient {
     });
   }
 
-  private async handleRequest<T>(request: () => Promise<T>): Promise<T> {
+  private static readonly MAX_RETRIES = 3;
+
+  private async handleRequest<T>(request: () => Promise<T>, retries = 0): Promise<T> {
     try {
       return await request();
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 429) {
-          // Rate limit exceeded, wait and retry
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          return this.handleRequest(request);
+          if (retries >= TrelloClient.MAX_RETRIES) {
+            throw new Error('Trello API rate limit exceeded after maximum retries');
+          }
+          // Rate limit exceeded, wait with exponential backoff and retry
+          const delay = 1000 * Math.pow(2, retries);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          return this.handleRequest(request, retries + 1);
         }
         throw new Error(`Trello API error: ${error.response?.data?.message ?? error.message}`);
       }
@@ -40,8 +46,27 @@ export class TrelloClient {
     }
   }
 
+  private async verifyListBelongsToBoard(listId: string): Promise<void> {
+    const response = await this.axiosInstance.get(`/lists/${listId}`, {
+      params: { fields: 'idBoard' },
+    });
+    if (response.data.idBoard !== this.config.boardId) {
+      throw new Error(`List ${listId} does not belong to the configured board`);
+    }
+  }
+
+  private async verifyCardBelongsToBoard(cardId: string): Promise<void> {
+    const response = await this.axiosInstance.get(`/cards/${cardId}`, {
+      params: { fields: 'idBoard' },
+    });
+    if (response.data.idBoard !== this.config.boardId) {
+      throw new Error(`Card ${cardId} does not belong to the configured board`);
+    }
+  }
+
   async getCardsByList(listId: string): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
+      await this.verifyListBelongsToBoard(listId);
       const response = await this.axiosInstance.get(`/lists/${listId}/cards`);
       return response.data;
     });
@@ -71,6 +96,7 @@ export class TrelloClient {
     labels?: string[];
   }): Promise<TrelloCard> {
     return this.handleRequest(async () => {
+      await this.verifyListBelongsToBoard(params.listId);
       const response = await this.axiosInstance.post('/cards', {
         idList: params.listId,
         name: params.name,
@@ -90,6 +116,7 @@ export class TrelloClient {
     labels?: string[];
   }): Promise<TrelloCard> {
     return this.handleRequest(async () => {
+      await this.verifyCardBelongsToBoard(params.cardId);
       const response = await this.axiosInstance.put(`/cards/${params.cardId}`, {
         name: params.name,
         desc: params.description,
@@ -102,6 +129,7 @@ export class TrelloClient {
 
   async archiveCard(cardId: string): Promise<TrelloCard> {
     return this.handleRequest(async () => {
+      await this.verifyCardBelongsToBoard(cardId);
       const response = await this.axiosInstance.put(`/cards/${cardId}`, {
         closed: true,
       });
@@ -121,6 +149,7 @@ export class TrelloClient {
 
   async archiveList(listId: string): Promise<TrelloList> {
     return this.handleRequest(async () => {
+      await this.verifyListBelongsToBoard(listId);
       const response = await this.axiosInstance.put(`/lists/${listId}/closed`, {
         value: true,
       });
@@ -131,19 +160,21 @@ export class TrelloClient {
   async getMyCards(): Promise<TrelloCard[]> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/members/me/cards');
-      return response.data;
+      return (response.data as TrelloCard[]).filter(
+        (card) => card.idBoard === this.config.boardId
+      );
     });
   }
 
-  async searchAllBoards(query: string, limit: number = 10): Promise<any> {
+  async searchBoard(query: string, limit: number = 10): Promise<any> {
     return this.handleRequest(async () => {
       const response = await this.axiosInstance.get('/search', {
         params: {
           query,
+          idBoards: this.config.boardId,
           modelTypes: 'all',
           boards_limit: limit,
           cards_limit: limit,
-          organization: true,
         },
       });
       return response.data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface TrelloCard {
   name: string;
   desc: string;
   due: string | null;
+  idBoard: string;
   idList: string;
   idLabels: string[];
   closed: boolean;

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -115,3 +115,13 @@ export function validateArchiveListRequest(args: Record<string, unknown>): { lis
     listId: validateString(args.listId, 'listId'),
   };
 }
+
+export function validateSearchRequest(args: Record<string, unknown>): { query: string; limit?: number } {
+  if (!args.query) {
+    throw new McpError(ErrorCode.InvalidParams, 'query is required');
+  }
+  return {
+    query: validateString(args.query, 'query'),
+    limit: validateOptionalNumber(args.limit),
+  };
+}


### PR DESCRIPTION
- Enforce board scoping on all card/list operations by verifying resources belong to the configured TRELLO_BOARD_ID before mutations
- Add idBoard to TrelloCard type (matches Trello API response)
- Filter getMyCards results to configured board only
- Scope search to configured board (renamed searchAllBoards -> searchBoard)
- Cap 429 retry loop at 3 attempts with exponential backoff
- Sanitize error logging to prevent credential leakage via AxiosError
- Log only tool name on requests, not full arguments with user content
- Wire up existing validators.ts instead of unsafe `as unknown as` casts
- Add validateSearchRequest for search tool input validation
- Fix rate limiter wait calculation (remove erroneous *1000 multiplier)
- Remove unused TrelloMember import